### PR TITLE
Updating the version number for WP 6.3 release

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, tour operator, specials, accommodation, prices 
 Requires at least: 5.3
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.2
-Stable tag: 1.3.5
+Stable tag: 1.3.6
 License: GPLv3
 
 With Tour Operator Specials, add deals to your website – a great way to entice people who are ready to take advantage of limited-time deals.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 # Change log
 
+## [[1.3.6]](https://github.com/lightspeeddevelopment/to-specials/releases/tag/1.3.6) - 2023-08-09
+
+### Fixes
+- Fixing the spacing above the "more" p tag.
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [[1.3.5]](https://github.com/lightspeeddevelopment/to-specials/releases/tag/1.3.5) - 2023-04-20
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "to-specials",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Tour Operators add-on for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/to-specials.php
+++ b/to-specials.php
@@ -3,7 +3,7 @@
  * Plugin Name: LSX Tour Operator Special Offers
  * Plugin URI:  https://www.lsdev.biz/product/tour-operator-special-offers/
  * Description: The Tour Operator Special Offers extension gives you the ability to create time-sensitive special prices that can be applied to Tour Operator post types you are using: Accommodations, destinations and/or tours.
- * Version:     1.3.5
+ * Version:     1.3.6
  * Author:      LightSpeed
  * Author URI:  https://www.lsdev.biz/
  * License:     GPL3+
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 define('LSX_TO_SPECIALS_PATH',  plugin_dir_path( __FILE__ ) );
 define('LSX_TO_SPECIALS_CORE',  __FILE__ );
 define('LSX_TO_SPECIALS_URL',  plugin_dir_url( __FILE__ ) );
-define('LSX_TO_SPECIALS_VER',  '1.3.5' );
+define('LSX_TO_SPECIALS_VER',  '1.3.6' );
 
 
 /* ======================= Below is the Plugin Class init ========================= */


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag